### PR TITLE
Corrected create_device when HiveMind is unavailable

### DIFF
--- a/hive-runner-ios.gemspec
+++ b/hive-runner-ios.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'hive-runner-ios'
-  s.version       = '1.1.6'
+  s.version       = '1.1.7'
   s.date          = Time.now.strftime("%Y-%m-%d")
   s.summary       = 'Hive Runner iOS'
   s.description   = 'The iOS controller module for Hive Runner'

--- a/lib/hive/controller/ios.rb
+++ b/lib/hive/controller/ios.rb
@@ -74,6 +74,7 @@ module Hive
                 'model' => device.model,
                 'brand' => 'Apple',
                 'os_version' => device.version,
+                'device_range' => device.device_class,
                 'queue_prefix' => @config['queue_prefix']
             }
           end
@@ -82,7 +83,7 @@ module Hive
             begin
               self.create_device(physical_device)
             rescue => e
-              Hive.logger.info("Could not created device: #{physical_device}");
+              Hive.logger.info("Could not create device: #{physical_device}");
             end
           end
         end


### PR DESCRIPTION
Fixes #28 